### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Camo Client
 ===========
 
 [![Build Status](https://travis-ci.org/sionide21/camo-client.png)](https://travis-ci.org/sionide21/camo-client)
-[![Latest Version](https://pypip.in/v/camo-client/badge.png)](https://pypi.python.org/pypi/camo-client/)
+[![Latest Version](https://img.shields.io/pypi/v/camo-client.svg)](https://pypi.python.org/pypi/camo-client/)
 
 A python client for Github's [Camo image proxy](https://github.com/atmos/camo).
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20camo-client))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `camo-client`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.