### PR TITLE
Client clean up

### DIFF
--- a/camo.py
+++ b/camo.py
@@ -11,20 +11,17 @@ class CamoClient(object):
         self.key = key
 
     def image_url(self, url):
-        return self.server + Image(url, self.key).path
-
-    def _rewrite_url(self, url):
         # skip images that have already been proxied and
         # images with data URIs
         if url.startswith(self.server) or url.startswith("data:image/"):
             return url
         else:
-            return self.image_url(url)
+            return self.server + Image(url, self.key).path
 
     def _rewrite_image_urls(self, node):
         for img in node.xpath('.//img'):
             if img.get('src'):
-                img.set('src', self._rewrite_url(img.get('src')))
+                img.set('src', self.image_url(img.get('src')))
         return node
 
     def parse_html(self, string):

--- a/camo.py
+++ b/camo.py
@@ -1,7 +1,6 @@
 import hashlib
 import hmac
 import re
-import urlparse
 from memoize import mproperty
 from lxml import html
 
@@ -14,14 +13,10 @@ class CamoClient(object):
     def image_url(self, url):
         return self.server + Image(url, self.key).path
 
-    def _is_absolute(self, url):
-        parsed_url = urlparse.urlparse(url.strip())
-        return bool(parsed_url.netloc)
-
     def _rewrite_url(self, url):
-        if url.startswith(self.server):
-            return url
-        elif not self._is_absolute(url):
+        # skip images that have already been proxied and
+        # images with data URIs
+        if url.startswith(self.server) or url.startswith("data:image/"):
             return url
         else:
             return self.image_url(url)

--- a/camo.py
+++ b/camo.py
@@ -32,13 +32,13 @@ class CamoClient(object):
         doc = self._rewrite_image_urls(doc)
         # iterating over a node returns all the tags within that node
         # ..if there are none, return the original string
-        return b''.join(map(html.tostring, doc)).decode() or string
+        return ''.join(map(html.tostring, doc)) or string
 
 
 class Image(object):
     def __init__(self, url, key):
-        self.url = bytes(url, 'utf-8')
-        self.key = bytes(key, 'utf-8')
+        self.url = url
+        self.key = key
 
     @mproperty
     def path(self):
@@ -50,4 +50,4 @@ class Image(object):
 
     @mproperty
     def encoded_url(self):
-        return self.url.hex()
+        return self.url.encode("hex")

--- a/camo.py
+++ b/camo.py
@@ -1,6 +1,7 @@
 import hashlib
 import hmac
 import re
+import urlparse
 from memoize import mproperty
 from lxml import html
 
@@ -13,10 +14,14 @@ class CamoClient(object):
     def image_url(self, url):
         return self.server + Image(url, self.key).path
 
+    def _is_absolute(self, url):
+        parsed_url = urlparse.urlparse(url.strip())
+        return bool(parsed_url.netloc)
+
     def _rewrite_url(self, url):
         if url.startswith(self.server):
             return url
-        elif not any(map(url.startswith, ["http://", "https://"])):
+        elif not self._is_absolute(url):
             return url
         else:
             return self.image_url(url)

--- a/camo.py
+++ b/camo.py
@@ -32,13 +32,13 @@ class CamoClient(object):
         doc = self._rewrite_image_urls(doc)
         # iterating over a node returns all the tags within that node
         # ..if there are none, return the original string
-        return ''.join(map(html.tostring, doc)) or string
+        return b''.join(map(html.tostring, doc)).decode() or string
 
 
 class Image(object):
     def __init__(self, url, key):
-        self.url = url
-        self.key = key
+        self.url = bytes(url, 'utf-8')
+        self.key = bytes(key, 'utf-8')
 
     @mproperty
     def path(self):
@@ -50,4 +50,4 @@ class Image(object):
 
     @mproperty
     def encoded_url(self):
-        return self.url.encode("hex")
+        return self.url.hex()

--- a/tests/camo_test.py
+++ b/tests/camo_test.py
@@ -25,9 +25,15 @@ class CamoClientTest(unittest.TestCase):
 
     def test_parses_html(self):
         client = CamoClient("https://fakecdn.org/", key="hello")
-        html = """<img src="http://example.net/images/hahafunny.jpg" /><img src="https://otherexample/moreserious.png" />"""
+        html = """<img src="http://example.net/images/hahafunny.jpg" /><img src="https://otherexample/moreserious.png" />"""\
+               """<img src="//example.net/no_http.jpg" /><img src=" http://example.net/leading_space.jpg" />"""\
+               """<img src=http://example.net/mising_quotes.jpg /><img src="ftp://example.net/ftp_image.jpg" />"""
         parsed = """<img src="https://fakecdn.org/735030fa488e1866b4302ac611c075d541a773e3/687474703a2f2f6578616d706c652e6e65742f696d616765732f6861686166756e6e792e6a7067">"""\
-                 """<img src="https://fakecdn.org/c81915f5756fad02cfae7d07e359624dae877667/68747470733a2f2f6f746865726578616d706c652f6d6f7265736572696f75732e706e67">"""
+                 """<img src="https://fakecdn.org/c81915f5756fad02cfae7d07e359624dae877667/68747470733a2f2f6f746865726578616d706c652f6d6f7265736572696f75732e706e67">"""\
+                 """<img src="https://fakecdn.org/1d5de168888358e62b7c2f850265c5bfb43e46c3/2f2f6578616d706c652e6e65742f6e6f5f687474702e6a7067">"""\
+                 """<img src="https://fakecdn.org/f4837f9cd17f391dd4c78e49f7b57934f6966f7c/20687474703a2f2f6578616d706c652e6e65742f6c656164696e675f73706163652e6a7067">"""\
+                 """<img src="https://fakecdn.org/d4ef06afe02debfdcbce1b1b078666e918732793/687474703a2f2f6578616d706c652e6e65742f6d6973696e675f71756f7465732e6a7067">"""\
+                 """<img src="https://fakecdn.org/46bb6a3963ac29bd9c1587f2f533dad926c82330/6674703a2f2f6578616d706c652e6e65742f6674705f696d6167652e6a7067">"""
         self.assertEqual(client.parse_html(html), parsed)
 
     def test_ignores_already_hosted(self):
@@ -38,6 +44,11 @@ class CamoClientTest(unittest.TestCase):
     def test_ignores_relative(self):
         client = CamoClient("https://fakecdn.org/", key="hello")
         html = """<p><img src="/images/hahafunny.jpg"></p>"""
+        self.assertEqual(client.parse_html(html), html)
+
+    def test_ignores_data_uri(self):
+        client = CamoClient("https://fakecdn.org/", key="hello")
+        html = """<p><img src="data:image/png;base64,iVBOR0t8XDY0bb"></p>"""
         self.assertEqual(client.parse_html(html), html)
 
     def test_unmarkedup_text(self):

--- a/tests/camo_test.py
+++ b/tests/camo_test.py
@@ -27,23 +27,20 @@ class CamoClientTest(unittest.TestCase):
         client = CamoClient("https://fakecdn.org/", key="hello")
         html = """<img src="http://example.net/images/hahafunny.jpg" /><img src="https://otherexample/moreserious.png" />"""\
                """<img src="//example.net/no_http.jpg" /><img src=" http://example.net/leading_space.jpg" />"""\
-               """<img src=http://example.net/mising_quotes.jpg /><img src="ftp://example.net/ftp_image.jpg" />"""
+               """<img src=http://example.net/mising_quotes.jpg /><img src="ftp://example.net/ftp_image.jpg" />"""\
+               """<img src="/images/hahafunny.jpg">"""
         parsed = """<img src="https://fakecdn.org/735030fa488e1866b4302ac611c075d541a773e3/687474703a2f2f6578616d706c652e6e65742f696d616765732f6861686166756e6e792e6a7067">"""\
                  """<img src="https://fakecdn.org/c81915f5756fad02cfae7d07e359624dae877667/68747470733a2f2f6f746865726578616d706c652f6d6f7265736572696f75732e706e67">"""\
                  """<img src="https://fakecdn.org/1d5de168888358e62b7c2f850265c5bfb43e46c3/2f2f6578616d706c652e6e65742f6e6f5f687474702e6a7067">"""\
                  """<img src="https://fakecdn.org/f4837f9cd17f391dd4c78e49f7b57934f6966f7c/20687474703a2f2f6578616d706c652e6e65742f6c656164696e675f73706163652e6a7067">"""\
                  """<img src="https://fakecdn.org/d4ef06afe02debfdcbce1b1b078666e918732793/687474703a2f2f6578616d706c652e6e65742f6d6973696e675f71756f7465732e6a7067">"""\
-                 """<img src="https://fakecdn.org/46bb6a3963ac29bd9c1587f2f533dad926c82330/6674703a2f2f6578616d706c652e6e65742f6674705f696d6167652e6a7067">"""
+                 """<img src="https://fakecdn.org/46bb6a3963ac29bd9c1587f2f533dad926c82330/6674703a2f2f6578616d706c652e6e65742f6674705f696d6167652e6a7067">"""\
+                 """<img src="https://fakecdn.org/17c855d7008b1307d277d725cb045b0fc0e23ea7/2f696d616765732f6861686166756e6e792e6a7067">"""
         self.assertEqual(client.parse_html(html), parsed)
 
     def test_ignores_already_hosted(self):
         client = CamoClient("https://fakecdn.org/", key="hello")
         html = """<p><img src="https://fakecdn.org/images/hahafunny.jpg"></p>"""
-        self.assertEqual(client.parse_html(html), html)
-
-    def test_ignores_relative(self):
-        client = CamoClient("https://fakecdn.org/", key="hello")
-        html = """<p><img src="/images/hahafunny.jpg"></p>"""
         self.assertEqual(client.parse_html(html), html)
 
     def test_ignores_data_uri(self):


### PR DESCRIPTION
As part of https://github.com/quantopian/nbconvert-sanitize/pull/15, I needed to expose `_rewrite_url`. It seemed to be better to combine `img_url` and `_rewrite_url` into .a single method, and use `img_url` in nbconvert-sanitize.